### PR TITLE
Unexport lookup_subnet_nif/3

### DIFF
--- a/src/erl_ip_index.erl
+++ b/src/erl_ip_index.erl
@@ -7,7 +7,6 @@
     async_build_index/1,
     lookup_ip/2,
     lookup_subnet/3,
-    lookup_subnet_nif/3,
     index_info/1
 ]).
 


### PR DESCRIPTION
Which is exported but shouldn't be.
