### PR TITLE
Remove wild card for compiling C files

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{port_specs, [{"priv/ip_index_nif.so", ["c_src/*.cpp", "c_src/*.c"]}]}.
+{port_specs, [{"priv/ip_index_nif.so", ["c_src/*.cpp"]}]}.
 {eunit_opts, [verbose]}.
 
 {plugins, [pc, rebar3_proper]}.


### PR DESCRIPTION
The port compiler has a new commit that fails when files are missing.
Since there are no .c files in c_src/, this commit fixes the
rebar.config setting.